### PR TITLE
Exception on loading BITONALTILE

### DIFF
--- a/src/Commands/TileElement.cs
+++ b/src/Commands/TileElement.cs
@@ -38,6 +38,7 @@ namespace codessentials.CGM.Commands
                         break;
                     default:
                         reader.Unsupported("unsupported compression type " + CompressionType);
+                        reader.ReadArgumentEnd();
                         break;
                 }
             }

--- a/src/IBinaryReader.cs
+++ b/src/IBinaryReader.cs
@@ -17,6 +17,7 @@ namespace codessentials.CGM
         string ReadString();
         int ReadIndex();
         int ReadInt();
+        int ReadArgumentEnd();
         string ReadFixedString();
         StructuredDataRecord ReadSDR();
         CgmColor ReadColor();

--- a/src/Import/DefaultBinaryReader.cs
+++ b/src/Import/DefaultBinaryReader.cs
@@ -508,6 +508,11 @@ namespace codessentials.CGM.Import
             return (_arguments[CurrentArg++] << 24) + (_arguments[CurrentArg++] << 16) + (_arguments[CurrentArg++] << 8) + _arguments[CurrentArg++];
         }
 
+        public int ReadArgumentEnd()
+        {
+            CurrentArg = ArgumentsCount;
+            return ArgumentsCount;
+        }
         public int SizeOfInt()
         {
             var precision = _cgm.IntegerPrecision;
@@ -1097,6 +1102,5 @@ MODE                            HATCH STYLE DEFINITION          duty cycle lengt
                 CurrentArg++;
             }
         }
-
     }
 }

--- a/src/Import/DefaultBinaryReader.cs
+++ b/src/Import/DefaultBinaryReader.cs
@@ -327,13 +327,16 @@ namespace codessentials.CGM.Import
             catch (NotSupportedException ex)
             {
                 _messages.Add(new Message(Severity.Unsupported, (ClassCode)elementClass, elementId, ex.Message, _currentCommand.ToString()));
+                ReadArgumentEnd();
             }
             catch (NotImplementedException ex)
             {
                 _messages.Add(new Message(Severity.Unimplemented, (ClassCode)elementClass, elementId, ex.Message, _currentCommand.ToString()));
+                ReadArgumentEnd();
             }
             catch (Exception ex)
             {
+                ReadArgumentEnd();
                 if (ex.Source == "FluentAssertions")
                     throw;
 


### PR DESCRIPTION
Regarding the issue #6, if an embedded graphic as TileElements were not read, the function `EnsureAllArgumentsWereRead` returned an error because the index of the `CurrentArg` were not set.

If a TileElement cannot be read because of the unsupported compression type, this is recorded in a message. But the reading of the CGM graphic should not be stopped completely. 

In this pull request I set the indexes with an additional function named `ReadArgumentEnd`