### PR TITLE
Read the arguments to the end in order to fully process CGM graphics even with unsupported elements.

### DIFF
--- a/src/Commands/BitonalTile.cs
+++ b/src/Commands/BitonalTile.cs
@@ -67,6 +67,7 @@ namespace codessentials.CGM.Commands
         protected override void ReadBitmap(IBinaryReader reader)
         {
             reader.Unsupported("BITMAP for BitonalTile");
+            reader.ReadArgumentEnd();
         }
 
         protected override void WriteBitmap(IBinaryWriter writer)

--- a/src/Commands/Tile.cs
+++ b/src/Commands/Tile.cs
@@ -87,6 +87,7 @@ namespace codessentials.CGM.Commands
         protected override void ReadBitmap(IBinaryReader reader)
         {
             reader.Unsupported("BITMAP for Tile");
+            reader.ReadArgumentEnd();
         }
 
         protected override void WriteBitmap(IBinaryWriter writer)


### PR DESCRIPTION
Regarding the issue https://github.com/twenzel/CGM/issues/6 as well as the pull request https://github.com/twenzel/CGM/pull/7, embedded graphic as TileElements were not read completely, which led to problems and the graphics could not be read to the end.

In this pull request skipped unsupported tile elements and reads the cgm fie completely.