### PR TITLE
Bugfix fall back to Windows-1252 when UTF-8 string decoding fails

### DIFF
--- a/src/Import/DefaultBinaryReader.cs
+++ b/src/Import/DefaultBinaryReader.cs
@@ -454,19 +454,22 @@ namespace codessentials.CGM.Import
 
         protected string ReadString(int length)
         {
+            var bytes = new byte[length];
             try
             {
-                var bytes = new byte[length];
                 for (var i = 0; i < length; i++)
-                {
                     bytes[i] = ReadByte();
-                }
-
-                return Encoding.UTF8.GetString(bytes);
             }
-            catch (Exception)
+            catch
             {
-                return new string(' ', length); // return empty spaces instead of garbled chars
+                return new string(' ', length);
+            }
+
+            try { return new UTF8Encoding(false, true).GetString(bytes); }
+            catch (DecoderFallbackException)
+            {
+                Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+                return Encoding.GetEncoding(1252).GetString(bytes);
             }
         }
 

--- a/src/Import/DefaultBinaryReader.cs
+++ b/src/Import/DefaultBinaryReader.cs
@@ -468,8 +468,7 @@ namespace codessentials.CGM.Import
             try { return new UTF8Encoding(false, true).GetString(bytes); }
             catch (DecoderFallbackException)
             {
-                Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
-                return Encoding.GetEncoding(1252).GetString(bytes);
+                return (CodePagesEncodingProvider.Instance.GetEncoding(1252) ?? Encoding.GetEncoding("ISO-8859-1")).GetString(bytes);
             }
         }
 

--- a/src/Import/DefaultBinaryReader.cs
+++ b/src/Import/DefaultBinaryReader.cs
@@ -23,6 +23,10 @@ namespace codessentials.CGM.Import
         internal static readonly double Two_Ex_16 = Math.Pow(2, 16);
         internal static readonly double Two_Ex_32 = Math.Pow(2, 32);
 
+        private static readonly UTF8Encoding StrictUtf8 = new UTF8Encoding(false, true);
+        private static readonly Encoding FallbackEncoding =
+            CodePagesEncodingProvider.Instance.GetEncoding(1252) ?? Encoding.GetEncoding("ISO-8859-1");
+
         public int CurrentArg { get; private set; } = 0;
         public byte[] Arguments => _arguments;
 
@@ -465,10 +469,10 @@ namespace codessentials.CGM.Import
                 return new string(' ', length);
             }
 
-            try { return new UTF8Encoding(false, true).GetString(bytes); }
+            try { return StrictUtf8.GetString(bytes); }
             catch (DecoderFallbackException)
             {
-                return (CodePagesEncodingProvider.Instance.GetEncoding(1252) ?? Encoding.GetEncoding("ISO-8859-1")).GetString(bytes);
+                return FallbackEncoding.GetString(bytes);
             }
         }
 

--- a/tests/BinaryWriterReaderTests.cs
+++ b/tests/BinaryWriterReaderTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+using System.Text;
 using codessentials.CGM.Commands;
 using codessentials.CGM.Export;
 using codessentials.CGM.Import;
@@ -71,6 +72,16 @@ namespace codessentials.CGM.Tests
             Test(w => w.WriteString("test"), r => _reader.ReadString().ShouldBe("test"));
         }
 
+        [Test]
+        public void String_InvalidUtf8_FallsBackToWindows1252()
+        {
+            var cp1252Bytes = new byte[] { 0xE4, 0xF6, 0xFC, 0xDF };
+            var expected = (CodePagesEncodingProvider.Instance.GetEncoding(1252)
+                ?? Encoding.GetEncoding("ISO-8859-1")).GetString(cp1252Bytes);
+
+            Test( w => {w.WriteByte((byte)cp1252Bytes.Length);
+                    foreach (var b in cp1252Bytes)
+                        w.WriteByte(b); }, r => _reader.ReadString().ShouldBe(expected));}
         [Test]
         public void String_Long()
         {


### PR DESCRIPTION
## Problem
`DefaultBinaryReader.ReadString` assumed strict UTF-8. Legacy CGM files using
Windows-1252 / ISO-8859-1 (e.g. German Umlauts) were either replaced by
U+FFFD or wiped to spaces by the catch-all.

## Fix
- Strict UTF-8 first (`UTF8Encoding(false, true)`).
- On `DecoderFallbackException`: fall back to Windows-1252, then ISO-8859-1.
- Register `CodePagesEncodingProvider` so legacy code pages work on .NET 5+.

## Impact
- No API changes.
- Valid UTF-8 behaves exactly as before.
- Umlauts in legacy files are now preserved instead of lost.